### PR TITLE
Update de link para download de Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 - Versão Windows (para computador): https://archive.org/download/irpf-2022-linux-x-86-64v-1.0/IRPF2022Win32v1.0.exe
 
-- Versão Mac (para computador): https://archive.org/download/irpf-2022-linux-x-86-64v-1.0/IRPF2022-v1.0.pkg
+- Versão Mac (para computador): https://downloadirpf.receita.fazenda.gov.br/irpf/2022/irpf/arquivos/IRPF2022-v1.1.pkg
 
 - Versão Linux 64 (para computador): https://archive.org/download/irpf-2022-linux-x-86-64v-1.0/IRPF2022Linux-x86_64v1.0.bin
 


### PR DESCRIPTION
O link antigo não estava conseguindo realizar o envio da declaração, baixei a nova versão e consegui enviar sem erro.